### PR TITLE
Fix capitalization of filename in #include directive

### DIFF
--- a/src/Pushbutton.h
+++ b/src/Pushbutton.h
@@ -2,7 +2,7 @@
 #define _Pushbutton_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.